### PR TITLE
Emit error info if BDIO submission fails

### DIFF
--- a/src/hub_pip/BlackDuckCore.py
+++ b/src/hub_pip/BlackDuckCore.py
@@ -114,8 +114,8 @@ class BlackDuckCore(object):
             linked_data_response = linked_data_data_service.upload_bdio(
                 bdio_data)
             info("Black Duck I/O successfully deployed to the hub")
-        except:
-            error(message="Failed to deploy Black Duck I/O to the hub", exit=self.fail)
+        except Exception as e:
+            error(message=e, exit=self.fail)
 
     def check_policies(self, tree):
         info("Checking component policy status")


### PR DESCRIPTION
If the BDIO submission to the hub fails emit the actual exception
information instead of a hard-coded error message.  This makes it
much easier to debug configuration or certificate problems with
the plugin.